### PR TITLE
Expand macro using loops

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -28,6 +28,19 @@ fn is_odd_rec(x: u128) -> bool {
     is_odd_rec_go(x, false)
 }
 
+#[tailcall]
+fn is_odd_rec_res_go(x: u128, odd: Result<bool, ()>) -> Result<bool, ()> {
+    if x > 0 {
+        is_odd_rec_res_go(x - 1, Ok(!odd?))
+    } else {
+        odd
+    }
+}
+
+fn is_odd_res_rec(x: u128) -> bool {
+    is_odd_rec_res_go(x, Ok(false)).unwrap()
+}
+
 // Same as `is_odd_rec_go`, but without the tailcall annotation.
 fn is_odd_boom_go(x: u128, odd: bool) -> bool {
     if x > 0 {
@@ -77,6 +90,14 @@ fn bench_oddness_rec(b: &mut Bencher) {
     });
 }
 
+fn bench_oddness_res_rec(b: &mut Bencher) {
+    let mut val: u128 = ODD_TEST_NUM;
+    b.iter(|| {
+        is_odd_res_rec(val);
+        val += 1;
+    });
+}
+
 fn bench_oddness_boom(b: &mut Bencher) {
     let mut val: u128 = ODD_TEST_NUM;
     b.iter(|| {
@@ -97,6 +118,7 @@ benchmark_group!(
     benches,
     bench_oddness_loop,
     bench_oddness_rec,
+    bench_oddness_res_rec,
     bench_oddness_boom,
     bench_oddness_mutrec
 );

--- a/impl/src/helpers.rs
+++ b/impl/src/helpers.rs
@@ -7,17 +7,14 @@ pub trait RewriteForBindLater {
 impl RewriteForBindLater for Pat {
     fn bind_later(&mut self) -> Vec<(Pat, Expr)> {
         match self {
-            Pat::Ident(PatIdent { ident, mutability, .. }) => {
+            Pat::Ident(PatIdent { attrs, subpat: None, mutability, ident, .. }) if attrs.is_empty() => {
                 vec![
                     (
                         Pat::Ident(PatIdent {
-                            // leave attrs, subpat, and by_ref in the original binding
                             attrs: vec![],
                             subpat: None,
                             by_ref: None,
-                            // take mutability to the new binding
                             mutability: mutability.take(),
-                            // use the same ident
                             ident: ident.clone(),
                         }),
                         parse_quote! { #ident },

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -38,6 +38,18 @@ fn memoized_factorial(input: u64, memo: &mut HashMap<u64, u64>) -> u64 {
     factorial_inner(1, input, memo)
 }
 
+#[tailcall]
+#[allow(dead_code)]
+fn add_iter<'a, I>(mut int_iter: I, accum: i32) -> i32
+where
+    I: Iterator<Item = &'a i32>,
+{
+    match int_iter.next() {
+        Some(i) => add_iter(int_iter, accum + i),
+        None => accum,
+    }
+}
+
 #[test]
 fn test_memoized_factorial_correctness() {
     let mut memo = HashMap::new();

--- a/tests/correctness_option.rs
+++ b/tests/correctness_option.rs
@@ -1,0 +1,26 @@
+use tailcall::*;
+
+/// Factorial artificial wrapped in a Option
+fn factorial(input: u64) -> Option<u64> {
+    #[tailcall]
+    fn factorial_inner(accumulator: Option<u64>, input: Option<u64>) -> Option<u64> {
+        let inp = input?;
+        let acc = accumulator?;
+        if inp > 0 {
+            factorial_inner(Some(acc * inp), Some(inp - 1))
+        } else {
+            Some(acc)
+        }
+    }
+
+    factorial_inner(Some(1), Some(input))
+}
+
+#[test]
+fn factorial_option_runs() {
+    assert_eq!(factorial(0).unwrap(), 1);
+    assert_eq!(factorial(1).unwrap(), 1);
+    assert_eq!(factorial(2).unwrap(), 2);
+    assert_eq!(factorial(3).unwrap(), 6);
+    assert_eq!(factorial(4).unwrap(), 24);
+}

--- a/tests/correctness_option.rs
+++ b/tests/correctness_option.rs
@@ -16,6 +16,18 @@ fn factorial(input: u64) -> Option<u64> {
     factorial_inner(Some(1), Some(input))
 }
 
+#[tailcall]
+#[allow(dead_code)]
+fn add_iter<'a, I>(mut int_iter: I, accum: i32) -> Option<i32>
+where
+    I: Iterator<Item = &'a i32>,
+{
+    match int_iter.next() {
+        Some(i) => add_iter(int_iter, accum + i),
+        None => Some(accum),
+    }
+}
+
 #[test]
 fn factorial_option_runs() {
     assert_eq!(factorial(0).unwrap(), 1);

--- a/tests/correctness_result.rs
+++ b/tests/correctness_result.rs
@@ -1,0 +1,30 @@
+use std::io::Error;
+use tailcall::*;
+
+/// Factorial artificial wrapped in a Result
+fn factorial(input: u64) -> Result<u64, Error> {
+    #[tailcall]
+    fn factorial_inner(
+        accumulator: Result<u64, Error>,
+        input: Result<u64, Error>,
+    ) -> Result<u64, Error> {
+        let inp = input?;
+        let acc = accumulator?;
+        if inp > 0 {
+            factorial_inner(Ok(acc * inp), Ok(inp - 1))
+        } else {
+            Ok(acc)
+        }
+    }
+
+    factorial_inner(Ok(1), Ok(input))
+}
+
+#[test]
+fn factorial_result_runs() {
+    assert_eq!(factorial(0).unwrap(), 1);
+    assert_eq!(factorial(1).unwrap(), 1);
+    assert_eq!(factorial(2).unwrap(), 2);
+    assert_eq!(factorial(3).unwrap(), 6);
+    assert_eq!(factorial(4).unwrap(), 24);
+}

--- a/tests/correctness_result.rs
+++ b/tests/correctness_result.rs
@@ -20,6 +20,18 @@ fn factorial(input: u64) -> Result<u64, Error> {
     factorial_inner(Ok(1), Ok(input))
 }
 
+#[tailcall]
+#[allow(dead_code)]
+fn add_iter<'a, I>(mut int_iter: I, accum: i32) -> Result<i32, ()>
+where
+    I: Iterator<Item = &'a i32>,
+{
+    match int_iter.next() {
+        Some(i) => add_iter(int_iter, accum + i),
+        None => Ok(accum),
+    }
+}
+
 #[test]
 fn factorial_result_runs() {
     assert_eq!(factorial(0).unwrap(), 1);


### PR DESCRIPTION
This is my attempt to solve a few problems at once.

Expanding the macro as a function call with a closure appealed to me originally because the core concept of the implementation (the "trampoline") could be factored out into support code. I also liked that it avoided introducing any new identifiers and that it didn't create a loop context (that would make `break` valid in places is was not previously).

That said, wrapping the user's code in a closure with a different return type comes with several downsides that I think ultimately outweigh the benefits:
* #5 - In stable Rust, the `?` operator only works in functions that return `Result` or `Option`.
* #9 - The compiler is not always able to infer the inner return type when generics are involved.
* #10 - The compiler cannot deduce that it is safe to move out of the closure in the final return _because it has no way to know statically that that return is in fact final_.  

Thank you, @bbarker, for finding and documenting these issues! The test cases here are lifted directly from his work in #6 .



